### PR TITLE
[EUDIW-178] Add platform-agnostic hardwarekey extractor

### DIFF
--- a/.changeset/fuzzy-games-yawn.md
+++ b/.changeset/fuzzy-games-yawn.md
@@ -1,0 +1,5 @@
+---
+"azure-functions-api": minor
+---
+
+[EUDIW-178] Add platform-agnostic hardwarekey extractor

--- a/apps/azure-functions-api/src/adapters/azure/functions/__tests__/create-wallet-instance.test.ts
+++ b/apps/azure-functions-api/src/adapters/azure/functions/__tests__/create-wallet-instance.test.ts
@@ -5,6 +5,7 @@ import { CreateWalletInstanceFn } from '../create-wallet-instance';
 import { makeHttpRequest } from './data';
 import { iOSMockData } from '../../../../domain/__tests__/hardwarekey-ios/data';
 import { androidMockData } from '../../../../domain/__tests__/hardwarekey-android/data';
+import { platformAgnosticMockData } from '../../../../domain/__tests__/hardwarekey-platform-agnostic/data';
 
 describe('CreateWalletInstanceFn', () => {
   it('should return a 204 HTTP response given valid ios data', async () => {
@@ -33,6 +34,25 @@ describe('CreateWalletInstanceFn', () => {
         challenge: androidMockData.challenge,
         hardware_key_tag: androidMockData.keyId,
         key_attestation: androidMockData.attestation,
+      },
+      { 'x-user-id': 'aUserId' },
+    );
+
+    env.nonceRepository.delete.mockReturnValueOnce(TE.right(void 0));
+    env.walletInstanceRepository.insert.mockReturnValueOnce(TE.right(void 0));
+
+    const actual = await CreateWalletInstanceFn(env)(request, ctx);
+
+    expect(actual.status).toStrictEqual(204);
+  });
+
+  it('should return a 204 HTTP response given valid platform-agnostic data', async () => {
+    const { env, ctx } = makeTestEnv();
+    const request = makeHttpRequest(
+      {
+        challenge: platformAgnosticMockData.challenge,
+        hardware_key_tag: platformAgnosticMockData.keyId,
+        key_attestation: platformAgnosticMockData.attestation,
       },
       { 'x-user-id': 'aUserId' },
     );

--- a/apps/azure-functions-api/src/domain/__tests__/hardwarekey-platform-agnostic/data.ts
+++ b/apps/azure-functions-api/src/domain/__tests__/hardwarekey-platform-agnostic/data.ts
@@ -1,0 +1,33 @@
+import { NonEmptyString } from '@pagopa/ts-commons/lib/strings';
+
+const challenge = 'randomvalue';
+
+const hardwareKey = {
+  crv: 'P-256',
+  kty: 'EC',
+  x: 'qk9Pf-luK80erkrbyiDQEGQRA4_yTzE_KbUnHXzrlaU',
+  y: '4n0ccO3SO8CrlDQdOFLi0guWzTvpLtuKX0k1tjexcpw',
+};
+
+const ephemeralKey = {
+  crv: 'P-256',
+  kty: 'EC',
+  x: 'gIX07BFk5_4lUvz18Rv462tUx4No-w_3MMs1zMNo9Pw',
+  y: '9xQ_iJISPbTzUziExHDm5Kv60yXc3DS1JfyaiIi9eBw',
+  kid: 'n6ItFM_OuMFVCGhWCh5zwkjs3l5sN-1StDWvMKf0WRk',
+};
+
+const integrityAssertion = 'anyStringButNonEmpty' as NonEmptyString;
+
+const attestation = Buffer.from(JSON.stringify(hardwareKey), 'binary').toString(
+  'base64',
+);
+
+export const platformAgnosticMockData = {
+  keyId: 'anHardwareKeyTag',
+  attestation,
+  challenge,
+  ephemeralKey,
+  hardwareKey,
+  integrityAssertion,
+};

--- a/apps/azure-functions-api/src/domain/hardwarekey-platform-agnostic.ts
+++ b/apps/azure-functions-api/src/domain/hardwarekey-platform-agnostic.ts
@@ -1,0 +1,29 @@
+import { pipe } from 'fp-ts/lib/function';
+import * as E from 'fp-ts/lib/Either';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as H from '@pagopa/handler-kit';
+import { CreateWalletInstanceBody as WalletInstanceRequest } from '../generated/definitions/endpoints/CreateWalletInstanceBody';
+import { JwkPublicKey } from './jwk';
+
+export const extractHardwareKeyFromPlatformAgnostic = (
+  request: WalletInstanceRequest,
+) =>
+  pipe(
+    E.tryCatch(
+      () =>
+        JSON.parse(
+          Buffer.from(request.key_attestation, 'base64').toString('utf-8'),
+        ),
+      () =>
+        new Error(
+          `[Platform Agnostic Hardware Key] Invalid attestation: ${request.key_attestation}`,
+        ),
+    ),
+    E.flatMap(
+      H.parse(
+        JwkPublicKey,
+        '[Platform Agnostic Hardware Key] Invalid attestation, invalid JWK format',
+      ),
+    ),
+    TE.fromEither,
+  );

--- a/apps/azure-functions-api/src/domain/key-attestation.ts
+++ b/apps/azure-functions-api/src/domain/key-attestation.ts
@@ -5,6 +5,7 @@ import { CreateWalletInstanceBody as WalletInstanceRequest } from '../generated/
 import { JwkPublicKey } from './jwk';
 import { extractHardwareKeyFromIOS } from './hardwarekey-ios';
 import { extractHardwareKeyFromAndroid } from './hardwarekey-android';
+import { extractHardwareKeyFromPlatformAgnostic } from './hardwarekey-platform-agnostic';
 
 export interface ValidKeyAttestation {
   // JWK public key
@@ -16,6 +17,7 @@ export const validateKeyAttestation = (request: WalletInstanceRequest) =>
     [
       extractHardwareKeyFromIOS(request),
       extractHardwareKeyFromAndroid(request),
+      extractHardwareKeyFromPlatformAgnostic(request),
     ],
     firstRightOrLefts,
     TE.mapError((errors) => new Error(`${errors.map((_) => _.message)}`)),


### PR DESCRIPTION
<!---
Please always add a PR description as if nobody knows anything about the context
these changes come from. Even if we are all from our internal team, we may not
be on the same page. Write this PR as you were contributing to a public OSS
project, where nobody knows you and you have to earn their trust. This will
improve our projects in the long run!

Thanks :).
-->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `extractHardwareKeyFromPlatformAgnostic` function

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To eliminate the dependency on the Integrity API, we need an alternative method to obtain the public key from the `key_attestation`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Checklist before requesting a review
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my code.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] My changes are about only one task or issue.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
