### PR TITLE
fix: [WLEO-990] add missing trust_chain, iat and exp claims in wallet attestation

### DIFF
--- a/apps/azure-functions-api/src/adapters/azure/functions/__tests__/create-wallet-attestations.test.ts
+++ b/apps/azure-functions-api/src/adapters/azure/functions/__tests__/create-wallet-attestations.test.ts
@@ -24,7 +24,7 @@ describe('CreateWalletAttestationFn', () => {
     env.walletInstanceRepository.get.mockReturnValueOnce(
       TE.right(O.some(await mkWalletInstance())),
     );
-    env.jwksRepository.get.mockReturnValueOnce(TE.right(aJwkKeyPair));
+    env.jwksRepository.get.mockReturnValue(TE.right(aJwkKeyPair));
 
     const actual = await CreateWalletAttestationFnV2(env)(request, ctx);
 

--- a/apps/azure-functions-api/src/domain/openid-federation.ts
+++ b/apps/azure-functions-api/src/domain/openid-federation.ts
@@ -5,7 +5,7 @@ import { pipe } from 'fp-ts/lib/function';
 // TODO: Move to configuration
 export const baseURL = 'https://io-d-itn-eudiw-api-func-01.azurewebsites.net';
 
-export const getFederationMetadata = pipe(
+const getFederationMetadataPayload = pipe(
   RTE.Do,
   RTE.apSW('jwks', getJwkPublicKeyList),
   RTE.map(({ jwks }) => ({
@@ -50,8 +50,14 @@ export const getFederationMetadata = pipe(
     },
     sub: baseURL,
   })),
+);
+
+export const getFederationEntityStatement = pipe(
+  getFederationMetadataPayload,
   RTE.flatMap((payload) =>
     signJwt({ header: { typ: 'entity-statement+jwt' }, payload }),
   ),
   RTE.map(({ jwt }) => jwt),
 );
+
+export const getFederationMetadata = getFederationEntityStatement;

--- a/apps/azure-functions-api/src/domain/wallet-attestations.ts
+++ b/apps/azure-functions-api/src/domain/wallet-attestations.ts
@@ -14,7 +14,7 @@ import { validateNonce } from './nonce';
 import { WalletInstance, getWalletInstance } from './wallet-instance';
 import { User } from './user';
 import { signJwt } from './signer';
-import { baseURL } from './openid-federation';
+import { baseURL, getFederationEntityStatement } from './openid-federation';
 
 export const WalletAttestationRequestHeader = t.type({
   alg: t.string,
@@ -123,18 +123,22 @@ const verifyHardwareSignature = (
 // TODO: Take baseURL and other information from openid-federation metadata
 const makeWalletAttestation = (war: WalletAttestationRequest) =>
   pipe(
-    RTE.of({
+    RTE.bindTo('entityConfigurationJwt')(getFederationEntityStatement),
+    RTE.map(({ entityConfigurationJwt }) => ({
       header: {
         typ: 'oauth-client-attestation+jwt',
+        trust_chain: [entityConfigurationJwt],
       },
       payload: {
         iss: baseURL,
         aal: `${baseURL}/LoA/basic`,
         sub: war.header.kid,
         cnf: war.payload.cnf,
+        exp: war.payload.exp,
+        iat: war.payload.iat,
         wallet_link: 'https://wp.example.org/',
         wallet_name: 'wp.example.org',
       },
-    }),
+    })),
     RTE.flatMap(signJwt),
   );


### PR DESCRIPTION
This pull request refactors how federation metadata and entity statements are handled in the wallet attestation flow, improving modularity and ensuring that JWTs are properly linked to the federation entity statement. The changes also update the wallet attestation creation logic to include additional fields and the trust chain in the JWT header.

Federation Metadata & Entity Statement Refactoring:

* Split the logic for fetching federation metadata into a new function `getFederationMetadataPayload`, and introduced `getFederationEntityStatement` to generate a signed JWT entity statement. `getFederationMetadata` now references `getFederationEntityStatement` for clarity and modularity. [[1]](diffhunk://#diff-c892319616601cc62a91e03c36f530714c66da836fbd726a2c502a0bbd722d09L8-R8) [[2]](diffhunk://#diff-c892319616601cc62a91e03c36f530714c66da836fbd726a2c502a0bbd722d09R53-R63)
* Updated imports in `wallet-attestations.ts` to use the new `getFederationEntityStatement` function, ensuring consistent access to federation entity statements.

Wallet Attestation JWT Improvements:

* Modified the wallet attestation creation logic to fetch the federation entity statement JWT and include it in the `trust_chain` array of the JWT header, along with new fields `exp` and `iat` in the payload. This strengthens attestation validity and traceability.

Test Consistency:

* Updated the mock setup in the wallet attestation tests to use `.mockReturnValue` instead of `.mockReturnValueOnce`, ensuring consistent test behavior.